### PR TITLE
Fix header guard typo in signal.h

### DIFF
--- a/signal.h
+++ b/signal.h
@@ -1,4 +1,4 @@
-#pragma onec
+#pragma once
 
 #define MAX_ARG_LEN 256 // ebpf stack max 512 bytes
 #define MAX_NAME_LEN 64


### PR DESCRIPTION
## Summary
- correct `#pragma onec` typo to `#pragma once` in `signal.h` to enable proper single inclusion

## Testing
- `cmake -S . -B build` *(fails: No download info given for 'libbpf')*
- `g++ -std=c++17 -I. /tmp/test.cpp -c 2>&1 | head -n 20` *(fails: __u64 does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68957ff1c8c0832abe2080cd621a3a16