### PR TITLE
Guard resume for null coroutine handle

### DIFF
--- a/waitable_map.hpp
+++ b/waitable_map.hpp
@@ -105,6 +105,12 @@ std::coroutine_handle<> chain_coroutines(std::coroutine_handle<Promise>&   resum
     return std::noop_coroutine();
 }
 
+template<typename MapContainer, typename Key>
+concept has_extract = requires(MapContainer &container, const Key &key)
+{
+    container.extract(key);
+};
+
 template<template<typename...> typename MapContainer,
          typename ContainerKey,
          typename T,
@@ -190,20 +196,30 @@ public:
     template<typename Key>
     auto resume(const Key& key)
     {
-        auto iterator = coroutines_.find(key);
-        if  (iterator != coroutines_.end())
+        // 檢測 coroutine map 是否支援 C++17 node handle（extract）
+        if constexpr (has_extract<coroutine_container_type, Key>)
         {
-            // 先 move handle 出來再 erase，避免在 resume() 期間插入新元素，導致 iterator 失效
-            auto handle = std::move(iterator->second);
+            // node-based 容器（std::map / std::unordered_map）會走這裡
+            auto node = coroutines_.extract(key);
+            if  (node && node.mapped())
+                 node.mapped().resume(); // handle.resume()
+        }
+        else
+        {
+            // 非 node-based 容器 (std::flat_map) 走這裡
+            auto iterator  = coroutines_.find(key);
+            if  (iterator != coroutines_.end())
+            {
+                // 先把 handle 移出，再從容器刪除元素
+                // 避免在 resume() 期間若發生插入/刪除造成元素搬移，導致 iterator 失效
+                auto handle = std::move(iterator->second);
+                coroutines_.erase(iterator);
 
-            coroutines_.erase(iterator);
-            // 如果呼叫 resume(key) 前沒有任何 coroutine 等待該 key，
-            // coroutines_[key] 會提供一個預設建構的空 handle。
-            // 只有在 handle 有效時才進行 resume，
-            // 讓使用者可以在不知道是否有等待 coroutine 的情況下直接呼叫 resume(key)，
-            // 保證操作的安全性。
-            if (handle)
-                handle.resume();
+                // 若 handle 為預設建構 (null)，代表沒有 coroutine 等待該 key
+                // 僅在 handle 有效時才 resume，以避免未定義行為。
+                if (handle)
+                    handle.resume();
+            }
         }
     }
 

--- a/waitable_map.hpp
+++ b/waitable_map.hpp
@@ -197,7 +197,13 @@ public:
             auto handle = std::move(iterator->second);
 
             coroutines_.erase(iterator);
-            handle.resume();
+            // 如果呼叫 resume(key) 前沒有任何 coroutine 等待該 key，
+            // coroutines_[key] 會提供一個預設建構的空 handle。
+            // 只有在 handle 有效時才進行 resume，
+            // 讓使用者可以在不知道是否有等待 coroutine 的情況下直接呼叫 resume(key)，
+            // 保證操作的安全性。
+            if (handle)
+                handle.resume();
         }
     }
 

--- a/waitable_map_test.cpp
+++ b/waitable_map_test.cpp
@@ -27,6 +27,10 @@ int main()
     map.try_emplace(10, 100);
     map.insert_or_assign(20, 200);
 
+    // Insert a key without any awaiting coroutine to ensure resume guard works
+    map.wait(30); // creates a default handle
+    map.insert_or_assign(30, 300); // should not crash
+
     std::println("done");
     return 0;
 }

--- a/waitable_map_test.cpp
+++ b/waitable_map_test.cpp
@@ -27,9 +27,9 @@ int main()
     map.try_emplace(10, 100);
     map.insert_or_assign(20, 200);
 
-    // Insert a key without any awaiting coroutine to ensure resume guard works
-    map.wait(30); // creates a default handle
-    map.insert_or_assign(30, 300); // should not crash
+    // 插入一個沒有任何 coroutine 在等待的 key 值，用來驗證 resume 的防護邏輯
+    map.wait(30);                  // 為該 key 建立預設 null handle
+    map.insert_or_assign(30, 300); // 不會觸發 resume 造成未定義的行為
 
     std::println("done");
     return 0;


### PR DESCRIPTION
## Summary
- Avoid resuming a null coroutine handle in `waitable_map::resume`
- Add regression test inserting a key with no awaiting coroutine
- Clarify why `resume` checks the handle before resuming

## Testing
- `g++ -std=c++23 waitable_map_test.cpp -fsanitize=address,undefined -fcoroutines -pthread -o waitable_map_test` *(fails: fatal error: print: No such file or directory)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68959cfbbe30832a8e02d55862d64efe